### PR TITLE
Use buildx for multi-architecture build

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,24 +54,33 @@ runs:
         RETURN_CODE=`docker manifest inspect ${{ steps.get-tag.outputs.tag }} > /dev/null && echo $? || echo $?`
         echo "::set-output name=need-build::$RETURN_CODE"
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1 
+      with:
+        username: ${{ inputs.registry-user }}
+        password: ${{ inputs.registry-pass }}
+
     - name: Update image tag in git
       working-directory: ${{ inputs.working-directory }}
       shell: bash
-      env:
-        REGISTRY_USER: ${{inputs.registry-user}}
-        REGISTRY_PASS: ${{inputs.registry-pass}}
       run: |
         set -x
 
+        ARGS="--platform linux/amd64,linux/arm64 -t ${{ steps.get-tag.outputs.tag }} -f ${{ inputs.docker-file }} ."
+
         # build docker image
         if [ "${{ steps.check-need-build.outputs.need-build }}" = "1" ]; then
-          docker build -t ${{ steps.get-tag.outputs.tag }} -f "${{ inputs.docker-file }}" .
+          docker buildx build --output "type=image,push=false" ${ARGS}
         
           if [ "${{ github.event_name }}" = "push" ]; then
-            # log into docker
-            echo "$REGISTRY_PASS" | docker login -u "$REGISTRY_USER" --password-stdin "${{ inputs.registry }}"
             # push
-            docker push ${{ steps.get-tag.outputs.tag }}
+            docker buildx build --output "type=image,push=true" ${ARGS}
             # avoid leaving docker login on disk for tasks that don't have access to secrets
             docker logout "${{ inputs.registry }}"
           fi


### PR DESCRIPTION
When I've been running buildx by hand, the build and push are done together; I think we want to keep them separate here.