### PR TITLE
Correct logic for checking tag existence

### DIFF
--- a/test_update_tags.py
+++ b/test_update_tags.py
@@ -55,9 +55,10 @@ def test_main(test_files, monkeypatch):
     out = update_tags.main(compose_path)
     assert out == f"::set-output name=services-to-rebuild::"
 
-    # 'push' action checks rebuild for all tags
+    # 'push' action checks rebuild for all tags if there are any
+    # changes -- but there aren't any at this point
     out = update_tags.main(compose_path, action='push')
-    assert out == f"::set-output name=services-to-rebuild::toplevel subdir"
+    assert out == f"::set-output name=services-to-rebuild::"
 
     # check hash values -- hashes are: build config, Dockerfile contents, x-hash-paths contents
     toplevel_hash = "bd018100e5b1c9159130decc1fa8884c"

--- a/update_tags.py
+++ b/update_tags.py
@@ -97,7 +97,9 @@ def main(docker_compose_path='docker-compose.yml', action='load'):
 
     # check which services need rebuild
     to_check = all_services if action == 'push' else [c[0] for c in changed_tags]
-    to_rebuild = [tag for tag in to_check if not remote_tag_exists(tag)]
+    to_rebuild = [c[0] for c in changed_tags
+                  if c[0] in to_check
+                  and not remote_tag_exists(c[2])]
 
     # string format to set steps.get-tag.outputs.rebuild_services if printed:
     print(f"Returning services-to-rebuild: {to_rebuild}")

--- a/update_tags.py
+++ b/update_tags.py
@@ -64,7 +64,7 @@ def get_changed_tags(override_path, override_text):
                 new_tag = f"{image_name}:{'.'.join(digits)}-{hash}"
                 changed_tags.append((service_name, old_tag, new_tag))
             else:
-                print(f" - No change")
+                print(" - No change")
         else:
             print(f"- Skipping {service_name}")
 


### PR DESCRIPTION
Previously, this was passing service names, not tags, to `remote_tag_exists()`.