### PR TITLE
Rely on `remote_tag_exists` rather than `changed_tags` for push

### DIFF
--- a/test_update_tags.py
+++ b/test_update_tags.py
@@ -56,9 +56,9 @@ def test_main(test_files, monkeypatch):
     assert out == f"::set-output name=services-to-rebuild::"
 
     # 'push' action checks rebuild for all tags if there are any
-    # changes -- but there aren't any at this point
+    # changes
     out = update_tags.main(compose_path, action='push')
-    assert out == f"::set-output name=services-to-rebuild::"
+    assert out == f"::set-output name=services-to-rebuild::toplevel subdir"
 
     # check hash values -- hashes are: build config, Dockerfile contents, x-hash-paths contents
     toplevel_hash = "bd018100e5b1c9159130decc1fa8884c"


### PR DESCRIPTION
Fixes #7