### PR TITLE
Update deprecated set-output command

### DIFF
--- a/test_update_tags.py
+++ b/test_update_tags.py
@@ -5,6 +5,7 @@ from shutil import copytree
 from textwrap import dedent
 
 import pytest
+import os
 
 import update_tags
 
@@ -48,17 +49,17 @@ def test_main(test_files, monkeypatch):
     monkeypatch.setattr(update_tags, 'remote_tag_exists', lambda *args: False)
 
     # first run detects changes to toplevel and subdir
-    out = update_tags.main(compose_path)
-    assert out == f"::set-output name=services-to-rebuild::toplevel subdir"
+    update_tags.main(compose_path)
+    assert github_output() == "services-to-rebuild=toplevel subdir"
 
     # no update the second time
-    out = update_tags.main(compose_path)
-    assert out == f"::set-output name=services-to-rebuild::"
+    update_tags.main(compose_path)
+    assert github_output() == "services-to-rebuild="
 
     # 'push' action checks rebuild for all tags if there are any
     # changes
-    out = update_tags.main(compose_path, action='push')
-    assert out == f"::set-output name=services-to-rebuild::toplevel subdir"
+    update_tags.main(compose_path, action='push')
+    assert github_output() == "services-to-rebuild=toplevel subdir"
 
     # check hash values -- hashes are: build config, Dockerfile contents, x-hash-paths contents
     toplevel_hash = "bd018100e5b1c9159130decc1fa8884c"
@@ -114,3 +115,15 @@ def test_run_from_command_line(monkeypatch):
     monkeypatch.setattr("sys.argv", ["foo", "-a", "push", "-f", "foo/docker-compose.yml"])
     monkeypatch.setattr(update_tags, 'main', main_patch)
     update_tags.run_from_command_line()
+
+
+def github_output():
+    """
+    This returns the last (i.e. current) non-blank line of the file
+    that GitHub uses to track action output. See
+    https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
+    which advises appending to this file.
+    """
+    return Path(
+        os.environ['GITHUB_OUTPUT']
+    ).read_text().rstrip().split('\n')[-1]

--- a/update_tags.py
+++ b/update_tags.py
@@ -2,6 +2,7 @@ import argparse
 import hashlib
 import requests
 from pathlib import Path
+import os
 
 import yaml
 
@@ -114,9 +115,10 @@ def main(docker_compose_path='docker-compose.yml', action='load'):
     else:
         to_rebuild = [c[0] for c in changed_tags if not remote_tag_exists(c[2])]
 
-    # string format to set steps.get-tag.outputs.rebuild_services if printed:
-    print(f"Returning services-to-rebuild: {to_rebuild}")
-    return f"::set-output name=services-to-rebuild::{' '.join(to_rebuild)}"
+    # append services-to-rebuild to GITHUB_OUTPUT
+    print(f"Setting services-to-rebuild: {to_rebuild}")
+    with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+        print(f"services-to-rebuild={' '.join(to_rebuild)}", file=fh)
 
 
 def run_from_command_line():

--- a/update_tags.py
+++ b/update_tags.py
@@ -2,7 +2,6 @@ import argparse
 import hashlib
 import requests
 from pathlib import Path
-import os.path
 
 import yaml
 
@@ -48,8 +47,8 @@ def get_changed_tags(override_path, override_text):
 
             # calculate new hash
             context = override_path.parent / build.get('context', '.')
-            docker_file_path = os.path.join(context, build.get('dockerfile', 'Dockerfile'))
-            hash_paths = sorted(set([docker_file_path] + [os.path.join(context, path) for path in build['x-hash-paths']]))
+            docker_file_path = context / build.get('dockerfile', 'Dockerfile')
+            hash_paths = sorted(set([docker_file_path] + [context / path for path in build['x-hash-paths']]))
             hash = get_hash(hash_paths, init_string=str(service['build']))
 
             # if new hash isn't in current tag, calculate new tag


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/