### PR TITLE
Update external actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,15 +40,15 @@ runs:
 
     - name: Set up QEMU
       if: steps.update-tags.outputs.services-to-rebuild != '' && inputs.bake-action == 'push'
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v3
 
     - name: Set up Docker Buildx
       if: steps.update-tags.outputs.services-to-rebuild != ''
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v3
 
     - name: Login to Docker Registry
       if: steps.update-tags.outputs.services-to-rebuild != '' && inputs.bake-action == 'push'
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         registry: ${{inputs.registry}}
         username: ${{inputs.registry-user}}


### PR DESCRIPTION
This is a follow-up to #9 -- the deprecation messages are still appearing in our builds, because of action dependencies.