### PR TITLE
Create buildx cache file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,6 +61,7 @@ runs:
       run: |
         set -x
 
+        touch /tmp/.buildx-cache
         BUILD_COMMAND="docker buildx bake -f docker-compose.yml -f docker-compose.override.yml ${{ steps.update-tags.outputs.services-to-rebuild }} \
                       --set *.cache-to=type=local,mode=max,dest=/tmp/.buildx-cache --set *.cache-from=type=local,src=/tmp/.buildx-cache"
 


### PR DESCRIPTION
A [build](https://github.com/harvard-lil/perma-scoop-api/actions/runs/12317914554/job/34382470890) is failing; the error is 

    ERROR: failed to evaluate path "/tmp/.buildx-cache": lstat /tmp/.buildx-cache: no such file or directory

The runner is a new runner, ([diff](https://github.com/actions/runner-images/compare/ubuntu20/20241201.1...ubuntu20/20241209.1)), and Docker-Buildx is new ([diff](https://github.com/docker/buildx/compare/v0.18.0...v0.19.2)); I haven't found evidence that the new version no longer implicitly creates the cache file, but let's explicitly create it, and see if the build will run.